### PR TITLE
US52-Task58 python script to read device output to CSV

### DIFF
--- a/python_scripts/readIntoCSV.py
+++ b/python_scripts/readIntoCSV.py
@@ -1,0 +1,20 @@
+import serial
+
+# Need to define port according to your setup, output is readable at 38400 baudrate
+serialPort = serial.Serial(port='COM3',baudrate=38400,bytesize=8,timeout=2,stopbits=serial.STOPBITS_ONE)
+
+# setup filewriting to CSV
+filename = "stream.csv"
+f = open(filename, "w")
+headers = "time,delta0,delta1,delta2,delta3,delta4\n"
+f.write(headers)
+
+# discard first line
+serialPort.readline()
+
+# change range value to collect more/less data points
+for x in range(500):
+    f.write(serialPort.readline().decode('utf-8'))
+
+serialPort.close()
+f.close()

--- a/qt7-ascii-out-light/qt7-dig-gain4/qtouch/datastreamer/datastreamer_UART_avr.c
+++ b/qt7-ascii-out-light/qt7-dig-gain4/qtouch/datastreamer/datastreamer_UART_avr.c
@@ -188,7 +188,7 @@ void ascii_output(void)
 
 	}
 	sequence++;
-	send_string("\r\n");
+	send_string("\n");
 
 
 }


### PR DESCRIPTION
To run this script, ensure the serial port is defined according to your setup. Removed '/r' from datastreamer output to avoid extra blank row.